### PR TITLE
feat(journal): Auto-detect Elite Dangerous journal directory #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,20 +90,23 @@ Then add to system packages:
 
 ### Running the App
 
-**Linux:**
+Just run the binary — the app auto-detects your Elite Dangerous journal directory on first launch. If it can't find it, a dialog will prompt you to select it.
+
 ```bash
-# Run with your Elite Dangerous journal directory
-./ed-expedition -j /path/to/steam/proton-prefix/.../Saved\ Games/Frontier\ Developments/Elite\ Dangerous/
+./ed-expedition        # Linux
+ed-expedition.exe      # Windows
 ```
 
-**Windows:**
-```powershell
-# Run with your Elite Dangerous journal directory
-ed-expedition.exe -j "%USERPROFILE%\Saved Games\Frontier Developments\Elite Dangerous\"
+You can override the journal directory with the `-j` flag or the `ED_EXPEDITION_JOURNAL_DIR` environment variable:
+
+```bash
+./ed-expedition -j /path/to/journals
+# or
+export ED_EXPEDITION_JOURNAL_DIR=/path/to/journals
+./ed-expedition
 ```
 
-> [!TIP]
-> The `-j` flag points to your Elite Dangerous journal directory for real-time tracking. The app will monitor new journal files as you play.
+The directory is saved after first use — subsequent launches remember it. The `-j` flag acts as a session override if a directory is already saved.
 
 ## Contributing
 
@@ -113,26 +116,14 @@ ED Expedition is built with [Wails v2](https://wails.io/docs/introduction) (Go b
 
 **Prerequisites:** Go 1.23+, Node.js, pnpm, and [Wails CLI](https://wails.io/docs/gettingstarted/installation)
 
-<details>
-<summary><strong>Nix users</strong></summary>
-
-`nix develop` provides all dependencies and sets up dev environment variables automatically.
-</details>
-
 ```bash
 # Run wails in development mode with hot reload
 # It handles installing dependencies and building everything
 wails dev
 ```
 
-> [!WARNING]
-> **Journal directory configuration:** The `-j` flag doesn't work with `wails dev` due to how Wails passes flags. The app defaults to `./data/journals` (see `main.go:24`). To test with real journal files, either:
-> - Copy/symlink your journal files to `./data/journals/`
-> - Use `cmd/simulate-log` to generate test journal events in `./data/journals/`
-> - Build the binary (`wails build`) and run it with `-j /path/to/journal`
-
 > [!TIP]
-> **Nix users:** `nix develop` automatically sets `ED_DEV_MODE`, `ED_EXPEDITION_DATA_DIR`, and `ED_EXPEDITION_CACHE_DIR` to local project directories.
+> **Nix users:** `nix develop` provides all dependencies and automatically sets `ED_DEV_MODE`, `ED_EXPEDITION_DATA_DIR`, `ED_EXPEDITION_CACHE_DIR`, and `ED_EXPEDITION_JOURNAL_DIR` to local project directories.
 
 > [!NOTE]
 > **Linux users:** If you get `webkit2gtk-4.0` pkg-config errors, you likely
@@ -192,6 +183,7 @@ Override with environment variables:
 ```bash
 export ED_EXPEDITION_DATA_DIR=/custom/path/to/data
 export ED_EXPEDITION_CACHE_DIR=/custom/path/to/cache
+export ED_EXPEDITION_JOURNAL_DIR=/path/to/journals
 ```
 
 **Dev Mode:**

--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"ed-expedition/journal"
+	"ed-expedition/lib/fs"
 	"ed-expedition/lib/job"
 	"ed-expedition/lib/vec"
 	"ed-expedition/models"
@@ -47,81 +48,59 @@ func NewApp(
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 
-	if err := a.initServices(); err != nil {
+	if err := a.initCoreServices(); err != nil {
 		a.logger.Error(err.Error())
 		os.Exit(1)
 	}
-	if err := a.startServices(); err != nil {
+	if err := a.startCoreServices(); err != nil {
 		a.logger.Error(err.Error())
 		os.Exit(1)
 	}
 
 	a.initAvailablePlotters()
 
-	a.jumpHistoryChan = a.expeditionService.JumpHistory.Subscribe()
-	go func() {
-		for event := range a.jumpHistoryChan {
-			runtime.EventsEmit(ctx, "JumpHistory", *event)
-			if next := a.expeditionService.GetNextSystemName(); next != nil {
-				runtime.ClipboardSetText(ctx, *next)
-			}
+	if a.journalDir != "" {
+		if err := a.startupJournalServices(); err != nil {
+			a.logger.Error(err.Error())
+			os.Exit(1)
 		}
-	}()
-
-	a.targetChan = a.journalWatcher.FSDTarget.Subscribe()
-	go func() {
-		for event := range a.targetChan {
-			runtime.EventsEmit(ctx, "Target", *event)
-		}
-	}()
-
-	a.completeExpeditionChan = a.expeditionService.CompleteExpedition.Subscribe()
-	go func() {
-		for event := range a.completeExpeditionChan {
-			runtime.EventsEmit(ctx, "CompleteExpedition", *event)
-		}
-	}()
-
-	a.currentJumpChan = a.expeditionService.CurrentJump.Subscribe()
-	go func() {
-		for event := range a.currentJumpChan {
-			runtime.EventsEmit(ctx, "CurrentJump", *event)
-		}
-	}()
-
-	a.fuelAlertChan = a.expeditionService.FuelAlert.Subscribe()
-	go func() {
-		for event := range a.fuelAlertChan {
-			runtime.EventsEmit(ctx, "FuelAlert", *event)
-		}
-	}()
-
-	a.jobStatusChan = a.jobService.JobStatus.Subscribe()
-	go func() {
-		for status := range a.jobStatusChan {
-			runtime.EventsEmit(ctx, "job:"+status.ID, *status)
-		}
-	}()
+	}
 }
 
-func (a *App) initServices() error {
-	a.logger.Info(fmt.Sprintf("[ed-expedition] starting watcher in '%s'", a.journalDir))
-
-	journalWatcher, err := journal.NewWatcher(a.journalDir, a.logger)
-	if err != nil {
-		return fmt.Errorf("failed to watch journal directory: %w", err)
+func (a *App) resolveJournalDir(state *models.AppState) string {
+	if a.journalDir != "" {
+		// -j was provided; save to app state only if this is the first time
+		if state.JournalDir == nil {
+			state.JournalDir = &a.journalDir
+			_ = models.SaveAppState(state)
+		}
+		return a.journalDir
 	}
-	a.journalWatcher = journalWatcher
 
-	stateService := services.NewAppStateService(journalWatcher, a.logger)
-	a.stateService = stateService
+	if state.JournalDir != nil {
+		return *state.JournalDir
+	}
+
+	detected := journal.DetectJournalDir()
+	if detected != "" {
+		state.JournalDir = &detected
+		_ = models.SaveAppState(state)
+		return detected
+	}
+
+	return ""
+}
+
+func (a *App) initCoreServices() error {
+	a.stateService = services.NewAppStateService(a.logger)
+
+	a.journalDir = a.resolveJournalDir(a.stateService.State)
 
 	var lastKnownLocation int64
-	if stateService.State.LastKnownLocation != nil {
-		lastKnownLocation = stateService.State.LastKnownLocation.SystemID
+	if a.stateService.State.LastKnownLocation != nil {
+		lastKnownLocation = a.stateService.State.LastKnownLocation.SystemID
 	}
-
-	a.expeditionService = services.NewExpeditionService(journalWatcher, a.logger, lastKnownLocation)
+	a.expeditionService = services.NewExpeditionService(a.logger, lastKnownLocation)
 
 	a.galaxyService = services.NewGalaxyService(a.logger)
 	a.jobService = services.NewJobService(a.logger)
@@ -129,26 +108,119 @@ func (a *App) initServices() error {
 	return nil
 }
 
-func (a *App) startServices() error {
-	a.expeditionService.Start()
-	a.stateService.Start()
+func (a *App) startCoreServices() error {
 	a.jobService.Start()
 
 	if err := a.galaxyService.Start(); err != nil {
 		return fmt.Errorf("failed to start galaxy service: %w", err)
 	}
 
+	a.jobStatusChan = a.jobService.JobStatus.Subscribe()
+	go func() {
+		for status := range a.jobStatusChan {
+			runtime.EventsEmit(a.ctx, "job:"+status.ID, *status)
+		}
+	}()
+
+	return nil
+}
+
+func (a *App) startupJournalServices() error {
+	a.logger.Info(fmt.Sprintf("[ed-expedition] watching journals in '%s'", a.journalDir))
+
+	watcher, err := journal.NewWatcher(a.journalDir, a.logger)
+	if err != nil {
+		return fmt.Errorf("failed to watch journal directory: %w", err)
+	}
+	a.journalWatcher = watcher
+
+	a.stateService.SetWatcher(watcher)
+	a.stateService.Start()
+
+	a.expeditionService.SetWatcher(watcher)
+	a.expeditionService.Start()
+
+	a.jumpHistoryChan = a.expeditionService.JumpHistory.Subscribe()
+	go func() {
+		for event := range a.jumpHistoryChan {
+			runtime.EventsEmit(a.ctx, "JumpHistory", *event)
+			if next := a.expeditionService.GetNextSystemName(); next != nil {
+				runtime.ClipboardSetText(a.ctx, *next)
+			}
+		}
+	}()
+
+	a.targetChan = watcher.FSDTarget.Subscribe()
+	go func() {
+		for event := range a.targetChan {
+			runtime.EventsEmit(a.ctx, "Target", *event)
+		}
+	}()
+
+	a.completeExpeditionChan = a.expeditionService.CompleteExpedition.Subscribe()
+	go func() {
+		for event := range a.completeExpeditionChan {
+			runtime.EventsEmit(a.ctx, "CompleteExpedition", *event)
+		}
+	}()
+
+	a.currentJumpChan = a.expeditionService.CurrentJump.Subscribe()
+	go func() {
+		for event := range a.currentJumpChan {
+			runtime.EventsEmit(a.ctx, "CurrentJump", *event)
+		}
+	}()
+
+	a.fuelAlertChan = a.expeditionService.FuelAlert.Subscribe()
+	go func() {
+		for event := range a.fuelAlertChan {
+			runtime.EventsEmit(a.ctx, "FuelAlert", *event)
+		}
+	}()
+
 	if a.expeditionService.Index.ActiveExpeditionID != nil && a.stateService.State.LastKnownLocation != nil {
-		err := a.journalWatcher.Sync(a.stateService.State.LastKnownLocation.Timestamp)
-		if err != nil {
+		if err := watcher.Sync(a.stateService.State.LastKnownLocation.Timestamp); err != nil {
 			return fmt.Errorf("failed to sync journal: %w", err)
 		}
 	}
 
 	a.logger.Info("[app.go] start journalWatcher")
-	a.journalWatcher.Start()
+	watcher.Start()
 
 	return nil
+}
+
+func (a *App) teardownJournalServices() {
+	if a.journalWatcher == nil {
+		return
+	}
+
+	if a.jumpHistoryChan != nil {
+		a.expeditionService.JumpHistory.Unsubscribe(a.jumpHistoryChan)
+		a.jumpHistoryChan = nil
+	}
+	if a.targetChan != nil {
+		a.journalWatcher.FSDTarget.Unsubscribe(a.targetChan)
+		a.targetChan = nil
+	}
+	if a.completeExpeditionChan != nil {
+		a.expeditionService.CompleteExpedition.Unsubscribe(a.completeExpeditionChan)
+		a.completeExpeditionChan = nil
+	}
+	if a.currentJumpChan != nil {
+		a.expeditionService.CurrentJump.Unsubscribe(a.currentJumpChan)
+		a.currentJumpChan = nil
+	}
+	if a.fuelAlertChan != nil {
+		a.expeditionService.FuelAlert.Unsubscribe(a.fuelAlertChan)
+		a.fuelAlertChan = nil
+	}
+
+	a.stateService.Stop()
+	a.expeditionService.Stop()
+
+	a.journalWatcher.Close()
+	a.journalWatcher = nil
 }
 
 func (a *App) initAvailablePlotters() {
@@ -162,39 +234,16 @@ func (a *App) initAvailablePlotters() {
 }
 
 func (a *App) shutdown(ctx context.Context) {
-	if a.jumpHistoryChan != nil && a.expeditionService != nil {
-		a.expeditionService.JumpHistory.Unsubscribe(a.jumpHistoryChan)
-	}
-	if a.targetChan != nil && a.journalWatcher != nil {
-		a.journalWatcher.FSDTarget.Unsubscribe(a.targetChan)
-	}
-	if a.completeExpeditionChan != nil && a.expeditionService != nil {
-		a.expeditionService.CompleteExpedition.Unsubscribe(a.completeExpeditionChan)
-	}
-	if a.currentJumpChan != nil && a.expeditionService != nil {
-		a.expeditionService.CurrentJump.Unsubscribe(a.currentJumpChan)
-	}
-	if a.fuelAlertChan != nil && a.expeditionService != nil {
-		a.expeditionService.FuelAlert.Unsubscribe(a.fuelAlertChan)
-	}
+	a.teardownJournalServices()
+
 	if a.jobStatusChan != nil && a.jobService != nil {
 		a.jobService.JobStatus.Unsubscribe(a.jobStatusChan)
 	}
-
 	if a.jobService != nil {
 		a.jobService.Stop()
 	}
 	if a.galaxyService != nil {
 		a.galaxyService.Stop()
-	}
-	if a.stateService != nil {
-		a.stateService.Stop()
-	}
-	if a.expeditionService != nil {
-		a.expeditionService.Stop()
-	}
-	if a.journalWatcher != nil {
-		a.journalWatcher.Close()
 	}
 }
 
@@ -358,6 +407,31 @@ func (a *App) AutocompleteSystems(prefix string) []string {
 
 func (a *App) DebugHilbertGroups(x, y, z, radius float64, useParallelQueries bool) *services.HilbertGroupDebug {
 	return a.galaxyService.DebugHilbertGroups(vec.NewVec3(x, y, z), radius, useParallelQueries)
+}
+
+func (a *App) GetJournalDirStatus() bool {
+	return a.journalWatcher != nil
+}
+
+func (a *App) BrowseJournalDir() (string, error) {
+	return runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
+		Title: "Select Elite Dangerous journal directory",
+	})
+}
+
+func (a *App) SetJournalDir(path string) error {
+	if !fs.IsDir(path) {
+		return fmt.Errorf("invalid directory: %s", path)
+	}
+
+	if err := a.stateService.SaveJournalDir(path); err != nil {
+		return fmt.Errorf("failed to save journal dir: %w", err)
+	}
+
+	a.teardownJournalServices()
+	a.journalDir = path
+
+	return a.startupJournalServices()
 }
 
 func (a *App) GetExpeditionSummaries() []models.ExpeditionSummary {

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             export ED_DEV_MODE=1
             export ED_EXPEDITION_DATA_DIR="$(pwd)/data/local/share"
             export ED_EXPEDITION_CACHE_DIR="$(pwd)/data/cache"
+            export ED_EXPEDITION_JOURNAL_DIR="$(pwd)/data/journals"
           '';
         };
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,6 +10,7 @@
   import ToastContainer from "./features/toasts/ToastContainer.svelte";
   import FuelAlertHandler from "./features/fuel/FuelAlertHandler.svelte";
   import GalaxyHandler from "./features/galaxy/GalaxyHandler.svelte";
+  import JournalDirHandler from "./features/journal/JournalDirHandler.svelte";
 
   const routes = {
     "/": ExpeditionIndex,
@@ -27,6 +28,7 @@
   <ToastContainer />
   <FuelAlertHandler />
   <GalaxyHandler />
+  <JournalDirHandler />
 </main>
 
 <style>

--- a/frontend/src/features/journal/JournalDirHandler.svelte
+++ b/frontend/src/features/journal/JournalDirHandler.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { toasts } from "../../lib/stores/toast";
+  import {
+    GetJournalDirStatus,
+    SetJournalDir,
+  } from "../../../wailsjs/go/main/App";
+  import JournalDirModal from "./JournalDirModal.svelte";
+
+  const TOAST_ID = "journal-dir";
+
+  let modalOpen = false;
+
+  onMount(async () => {
+    const configured = await GetJournalDirStatus();
+    if (!configured) {
+      modalOpen = true;
+    }
+  });
+
+  async function handleConfirm(path: string) {
+    try {
+      await SetJournalDir(path);
+      modalOpen = false;
+      toasts.set(TOAST_ID, {
+        title: "Journal Directory",
+        message: "Journal directory configured successfully.",
+        level: "success",
+        dismissable: true,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toasts.set(TOAST_ID, {
+        title: "Journal Directory",
+        message: `Failed to set journal directory: ${msg}`,
+        level: "danger",
+        dismissable: true,
+      });
+    }
+  }
+</script>
+
+<JournalDirModal
+  bind:open={modalOpen}
+  onConfirm={handleConfirm}
+/>

--- a/frontend/src/features/journal/JournalDirModal.svelte
+++ b/frontend/src/features/journal/JournalDirModal.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import Modal from "../../components/Modal.svelte";
+  import Button from "../../components/Button.svelte";
+  import TextInput from "../../components/TextInput.svelte";
+  import { BrowseJournalDir } from "../../../wailsjs/go/main/App";
+
+  export let open: boolean = false;
+  export let onConfirm: (path: string) => void;
+
+  let path: string = "";
+  let error: string = "";
+
+  async function handleBrowse() {
+    try {
+      const selected = await BrowseJournalDir();
+      if (selected) {
+        path = selected;
+        error = "";
+      }
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  function handleConfirm() {
+    if (!path.trim()) {
+      error = "Please select or enter a directory path";
+      return;
+    }
+    error = "";
+    onConfirm(path.trim());
+  }
+
+</script>
+
+<Modal {open} title="Journal Directory" showCloseButton={false}>
+  <div class="content">
+    <p>
+      ED Expedition needs to know where your
+      <strong>Elite Dangerous journal files</strong> are located to track your
+      jumps in real-time.
+    </p>
+
+    <div class="input-row">
+      <div class="input-field">
+        <TextInput
+          bind:value={path}
+          placeholder="/path/to/journal/directory"
+          label="Journal directory"
+        />
+      </div>
+      <Button variant="secondary" onClick={handleBrowse}>Browse</Button>
+    </div>
+
+    {#if error}
+      <p class="error">{error}</p>
+    {/if}
+
+    <div class="actions">
+      <Button onClick={handleConfirm} disabled={!path.trim()}>Confirm</Button>
+    </div>
+  </div>
+</Modal>
+
+<style>
+  .content {
+    padding: 1.5rem;
+    max-width: 480px;
+  }
+
+  .content p {
+    margin: 0 0 1.25rem;
+    color: var(--ed-text-primary);
+    line-height: 1.5;
+  }
+
+  .content strong {
+    color: var(--ed-orange);
+  }
+
+  .input-row {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-end;
+    margin-bottom: 1.25rem;
+  }
+
+  .input-field {
+    flex: 1;
+  }
+
+  .error {
+    color: var(--ed-danger);
+    font-size: 0.85rem;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+  }
+</style>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -9,6 +9,8 @@ export function AcceptGalaxy():Promise<string>;
 
 export function AutocompleteSystems(arg1:string):Promise<Array<string>>;
 
+export function BrowseJournalDir():Promise<string>;
+
 export function ContinueGalaxyBuild():Promise<string>;
 
 export function CreateExpedition():Promise<string>;
@@ -29,6 +31,8 @@ export function GetExpeditionSummaries():Promise<Array<models.ExpeditionSummary>
 
 export function GetGalaxyState():Promise<main.GalaxyStatus>;
 
+export function GetJournalDirStatus():Promise<boolean>;
+
 export function GetPlotterInputConfig(arg1:string):Promise<Array<plotters.PlotterInputFieldConfig>>;
 
 export function GetPlotterOptions():Promise<Record<string, string>>;
@@ -46,6 +50,8 @@ export function PlotRoute(arg1:string,arg2:string,arg3:string,arg4:string,arg5:p
 export function RemoveRouteFromExpedition(arg1:string,arg2:string):Promise<void>;
 
 export function RenameExpedition(arg1:string,arg2:string):Promise<void>;
+
+export function SetJournalDir(arg1:string):Promise<void>;
 
 export function StartExpedition(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -10,6 +10,10 @@ export function AutocompleteSystems(arg1) {
   return window['go']['main']['App']['AutocompleteSystems'](arg1);
 }
 
+export function BrowseJournalDir() {
+  return window['go']['main']['App']['BrowseJournalDir']();
+}
+
 export function ContinueGalaxyBuild() {
   return window['go']['main']['App']['ContinueGalaxyBuild']();
 }
@@ -50,6 +54,10 @@ export function GetGalaxyState() {
   return window['go']['main']['App']['GetGalaxyState']();
 }
 
+export function GetJournalDirStatus() {
+  return window['go']['main']['App']['GetJournalDirStatus']();
+}
+
 export function GetPlotterInputConfig(arg1) {
   return window['go']['main']['App']['GetPlotterInputConfig'](arg1);
 }
@@ -84,6 +92,10 @@ export function RemoveRouteFromExpedition(arg1, arg2) {
 
 export function RenameExpedition(arg1, arg2) {
   return window['go']['main']['App']['RenameExpedition'](arg1, arg2);
+}
+
+export function SetJournalDir(arg1) {
+  return window['go']['main']['App']['SetJournalDir'](arg1);
 }
 
 export function StartExpedition(arg1) {

--- a/journal/detect.go
+++ b/journal/detect.go
@@ -1,0 +1,49 @@
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// edProtonSuffix is the fixed path from a Steam root to the ED journal directory.
+const edProtonSuffix = "steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/Frontier Developments/Elite Dangerous"
+
+func journalDirCandidates() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	switch runtime.GOOS {
+	case "windows":
+		return []string{
+			filepath.Join(home, "Saved Games", "Frontier Developments", "Elite Dangerous"),
+		}
+	case "linux":
+		steamRoots := []string{
+			filepath.Join(home, ".local", "share", "Steam"),
+			filepath.Join(home, ".steam", "steam"),
+			filepath.Join(home, ".steam", "debian-installation"),
+			filepath.Join(home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
+		}
+		candidates := make([]string, len(steamRoots))
+		for i, root := range steamRoots {
+			candidates[i] = filepath.Join(root, edProtonSuffix)
+		}
+		return candidates
+	default:
+		return nil
+	}
+}
+
+// DetectJournalDir returns the first auto-detected ED journal directory that
+// exists on the system. Returns empty string if none found.
+func DetectJournalDir() string {
+	for _, dir := range journalDirCandidates() {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"ed-expedition/lib/fs"
 	"ed-expedition/models"
 	"embed"
 	"flag"
@@ -23,12 +22,8 @@ var icon []byte
 func main() {
 	logger := wailsLogger.NewDefaultLogger()
 
-	journalDir := flag.String("j", "./data/journals", "The path to the journal files")
+	journalDir := flag.String("j", os.Getenv("ED_EXPEDITION_JOURNAL_DIR"), "Elite Dangerous journal directory (default: $ED_EXPEDITION_JOURNAL_DIR)")
 	flag.Parse()
-	if len(*journalDir) == 0 || !fs.IsDir(*journalDir) {
-		logger.Error("Missing or invalid `-j` flag. You must provide a valid directory.")
-		os.Exit(1)
-	}
 
 	app := NewApp(logger, *journalDir)
 

--- a/models/app_state.go
+++ b/models/app_state.go
@@ -20,6 +20,8 @@ type AppState struct {
 
 	GalaxyDecision     GalaxyDecision `json:"galaxy_decision,omitempty"`
 	GalaxyDownloadedAt *time.Time     `json:"galaxy_downloaded_at,omitempty"`
+
+	JournalDir *string `json:"journal_dir,omitempty"`
 }
 
 type Loadout struct {

--- a/services/app_state.go
+++ b/services/app_state.go
@@ -20,20 +20,27 @@ type AppStateService struct {
 	logger       wailsLogger.Logger
 }
 
-func NewAppStateService(watcher *journal.Watcher, logger wailsLogger.Logger) *AppStateService {
+func NewAppStateService(logger wailsLogger.Logger) *AppStateService {
 	state, err := models.LoadAppState()
 	if err != nil {
 		panic(err)
 	}
 
 	return &AppStateService{
-		State:   state,
-		watcher: watcher,
-		logger:  logger,
+		State:  state,
+		logger: logger,
 	}
 }
 
+func (s *AppStateService) SetWatcher(w *journal.Watcher) {
+	s.watcher = w
+}
+
 func (s *AppStateService) Start() {
+	if s.watcher == nil || s.loadoutChan != nil {
+		return
+	}
+
 	s.loadoutChan = s.watcher.Loadout.Subscribe()
 
 	go func() {
@@ -106,6 +113,11 @@ func (s *AppStateService) Start() {
 	}()
 }
 
+func (s *AppStateService) SaveJournalDir(path string) error {
+	s.State.JournalDir = &path
+	return models.SaveAppState(s.State)
+}
+
 func (s *AppStateService) AcceptGalaxy() error {
 	now := time.Now()
 	s.State.GalaxyDecision = models.GalaxyAccepted
@@ -119,6 +131,9 @@ func (s *AppStateService) DeclineGalaxy() error {
 }
 
 func (s *AppStateService) Stop() error {
+	if s.watcher == nil {
+		return nil
+	}
 	if s.loadoutChan != nil {
 		s.watcher.Loadout.Unsubscribe(s.loadoutChan)
 		s.loadoutChan = nil

--- a/services/expedition.go
+++ b/services/expedition.go
@@ -35,7 +35,7 @@ type ExpeditionService struct {
 	FuelAlert          *channels.FanoutChannel[*FuelAlert]
 }
 
-func NewExpeditionService(watcher *journal.Watcher, logger wailsLogger.Logger, currentSystem int64) *ExpeditionService {
+func NewExpeditionService(logger wailsLogger.Logger, currentSystem int64) *ExpeditionService {
 	index, err := models.LoadIndex()
 	if err != nil {
 		panic(err)
@@ -69,8 +69,7 @@ func NewExpeditionService(watcher *journal.Watcher, logger wailsLogger.Logger, c
 		currentJump:        currentJump,
 		previouslyScooping: false,
 
-		watcher: watcher,
-		logger:  logger,
+		logger: logger,
 
 		JumpHistory: channels.NewFanoutChannel[*models.JumpHistoryEntry](
 			"JumpHistory", 0, 5*time.Millisecond, logger,
@@ -87,7 +86,15 @@ func NewExpeditionService(watcher *journal.Watcher, logger wailsLogger.Logger, c
 	}
 }
 
+func (e *ExpeditionService) SetWatcher(w *journal.Watcher) {
+	e.watcher = w
+}
+
 func (e *ExpeditionService) Start() {
+	if e.watcher == nil || e.fsdJumpChan != nil {
+		return
+	}
+
 	e.fsdJumpChan = e.watcher.FSDJump.Subscribe()
 	go func() {
 		for event := range e.fsdJumpChan {
@@ -126,6 +133,9 @@ func (e *ExpeditionService) Start() {
 }
 
 func (e *ExpeditionService) Stop() error {
+	if e.watcher == nil {
+		return nil
+	}
 	if e.fsdJumpChan != nil {
 		e.watcher.FSDJump.Unsubscribe(e.fsdJumpChan)
 		e.fsdJumpChan = nil

--- a/services/expedition_test.go
+++ b/services/expedition_test.go
@@ -76,7 +76,8 @@ func (s *ExpeditionServiceTestSuite) SetupTest() {
 	}
 
 	currentSystemId := int64(0)
-	s.service = NewExpeditionService(s.watcher, &TestLogger{}, currentSystemId)
+	s.service = NewExpeditionService(&TestLogger{}, currentSystemId)
+	s.service.SetWatcher(s.watcher)
 	s.service.Start()
 	s.watcher.Start()
 


### PR DESCRIPTION
The app no longer requires a `-j` flag. On first launch it resolves the journal directory automatically:

1. `-j` flag / `ED_EXPEDITION_JOURNAL_DIR` env var
2. Previously saved directory (persisted in app state)
3. Auto-detection from known Steam paths (native, Flatpak, Debian)
4. GUI prompt — a blocking modal asks the user to browse/enter the path

The directory is saved to app state after first discovery. On subsequent runs, `-j` acts as a session-only override.

**Backend changes:**
- `journal/detect.go` — scans common Steam root locations per OS
- `models/app_state.go` — new `JournalDir` field
- `app.go` — refactored into `startupJournalServices`/`teardownJournalServices` so journal services can be started after the user sets the directory via GUI
- Services gain `SetWatcher()` for deferred watcher injection with idempotent `Start()`/`Stop()`

**Frontend changes:**
- Journal directory modal (no dismiss — the app requires it to function)
- Opens automatically on startup when unconfigured

Closes #40