### PR TITLE
fix(journal): Hash-based dedup for sync boundary events #39

### DIFF
--- a/app.go
+++ b/app.go
@@ -178,8 +178,8 @@ func (a *App) startupJournalServices() error {
 		}
 	}()
 
-	if a.expeditionService.Index.ActiveExpeditionID != nil && a.stateService.State.LastKnownLocation != nil {
-		if err := watcher.Sync(a.stateService.State.LastKnownLocation.Timestamp); err != nil {
+	if a.expeditionService.Index.ActiveExpeditionID != nil && a.stateService.State.JournalSync != nil {
+		if err := watcher.Sync(*a.stateService.State.JournalSync); err != nil {
 			return fmt.Errorf("failed to sync journal: %w", err)
 		}
 	}

--- a/journal/sync.go
+++ b/journal/sync.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"ed-expedition/models"
 	"errors"
 	"fmt"
 	"os"
@@ -12,8 +13,8 @@ import (
 
 // Looks over all logs at and after the provided timestamp and emits configured
 // events from these
-func (jw *Watcher) Sync(since time.Time) error {
-	jw.logger.Trace(fmt.Sprintf("[Sync] Called with since=%v", since))
+func (jw *Watcher) Sync(syncState models.JournalSync) error {
+	jw.logger.Trace(fmt.Sprintf("[Sync] Called with since=%v hash=%s", syncState.Timestamp, syncState.EventHash))
 	if jw.started {
 		return errors.New("Cannot call journal.Watcher.Sync() after the watcher has been started")
 	}
@@ -61,7 +62,7 @@ func (jw *Watcher) Sync(since time.Time) error {
 	// event that are after our provided 'since'
 	// Regardless, since each timestamp of every event handled by 'processData'
 	// is checked against 'since', we'll never process event's we should not.
-	cutoff := slices.IndexFunc(journals, func(j *JournalName) bool { return j.time.After(since) })
+	cutoff := slices.IndexFunc(journals, func(j *JournalName) bool { return j.time.After(syncState.Timestamp) })
 	jw.logger.Trace(fmt.Sprintf("[Sync] IndexFunc returned: %d", cutoff))
 	if cutoff < 0 {
 		cutoff = len(journals) - 1
@@ -82,7 +83,7 @@ func (jw *Watcher) Sync(since time.Time) error {
 	journals = journals[cutoff:]
 	jw.logger.Trace(fmt.Sprintf("[Sync] Processing %d journals starting from index %d", len(journals), cutoff))
 
-	jw.lastTimestamp = since
+	var lastLine *parsedLine
 	for i, journal := range journals {
 		jw.logger.Trace(fmt.Sprintf("[Sync] Processing journal %d: %s", i, journal.name))
 		content, err := os.ReadFile(path.Join(jw.dir, journal.name))
@@ -96,8 +97,17 @@ func (jw *Watcher) Sync(since time.Time) error {
 			return err
 		}
 
-		lines = jw.filterSyncBoundary(lines)
+		lines = jw.filterSyncBoundary(lines, &syncState)
+		if len(lines) == 0 {
+			continue
+		}
+
 		jw.dispatch(lines)
+		lastLine = &lines[len(lines)-1]
+	}
+
+	if lastLine != nil {
+		jw.publishSyncState(*lastLine)
 	}
 
 	jw.logger.Trace("[Sync] Complete")

--- a/journal/sync.go
+++ b/journal/sync.go
@@ -90,10 +90,14 @@ func (jw *Watcher) Sync(since time.Time) error {
 			return err
 		}
 		jw.logger.Trace(fmt.Sprintf("[Sync] Read %d bytes from %s", len(content), journal.name))
-		err = jw.processData(content)
+
+		lines, err := jw.parseLines(content)
 		if err != nil {
 			return err
 		}
+
+		lines = jw.filterSyncBoundary(lines)
+		jw.dispatch(lines)
 	}
 
 	jw.logger.Trace("[Sync] Complete")

--- a/journal/sync.go
+++ b/journal/sync.go
@@ -97,6 +97,9 @@ func (jw *Watcher) Sync(syncState models.JournalSync) error {
 			return err
 		}
 
+		jw.currentFile = journal.name
+		jw.seek = int64(len(content))
+
 		lines = jw.filterSyncBoundary(lines, &syncState)
 		if len(lines) == 0 {
 			continue

--- a/journal/watcher.go
+++ b/journal/watcher.go
@@ -134,87 +134,114 @@ func (jw *Watcher) handleJournalUpdate() error {
 		}
 	}
 
-	err = jw.processData(buf)
+	lines, err := jw.parseLines(buf)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to process journal data: %v", err))
+		panic(fmt.Sprintf("Failed to parse journal data: %v", err))
 	}
+
+	jw.dispatch(lines)
 
 	return nil
 }
 
-func (jw *Watcher) processData(data []byte) error {
-	lines := slice.Split(data, '\n')
-	jw.logger.Trace(fmt.Sprintf("[processData] Processing %d lines, lastTimestamp=%v", len(lines), jw.lastTimestamp))
+type parsedLine struct {
+	Raw       []byte
+	Timestamp time.Time
+	Event     EventType
+}
 
-	for i, line := range lines {
+func (jw *Watcher) parseLines(data []byte) ([]parsedLine, error) {
+	rawLines := slice.Split(data, '\n')
+	jw.logger.Trace(fmt.Sprintf("[parseLines] Processing %d lines", len(rawLines)))
+
+	parsed := make([]parsedLine, 0, len(rawLines))
+
+	for i, line := range rawLines {
 		if len(line) == 0 {
-			jw.logger.Trace(fmt.Sprintf("[processData] Line %d: empty, skipping", i))
 			continue
 		}
 
-		jw.logger.Trace(fmt.Sprintf("[processData] Line %d: %s", i, string(line)))
+		jw.logger.Trace(fmt.Sprintf("[parseLines] Line %d: %s", i, string(line)))
 
 		var base struct {
 			Timestamp time.Time `json:"timestamp"`
 			Event     EventType `json:"event"`
 		}
-		err := json.Unmarshal(line, &base)
-		if err != nil {
-			jw.logger.Trace(fmt.Sprintf("[processData] Line %d: unmarshal error: %v", i, err))
-			return err
+		if err := json.Unmarshal(line, &base); err != nil {
+			jw.logger.Trace(fmt.Sprintf("[parseLines] Line %d: unmarshal error: %v", i, err))
+			return nil, err
 		}
 
-		jw.logger.Trace(fmt.Sprintf("[processData] Line %d: event=%s timestamp=%v", i, base.Event, base.Timestamp))
+		jw.logger.Trace(fmt.Sprintf("[parseLines] Line %d: event=%s timestamp=%v", i, base.Event, base.Timestamp))
 
-		if base.Timestamp.Before(jw.lastTimestamp) {
-			jw.logger.Trace(fmt.Sprintf("[processData] Line %d: timestamp %v not after lastTimestamp %v, skipping", i, base.Timestamp, jw.lastTimestamp))
+		parsed = append(parsed, parsedLine{
+			Raw:       line,
+			Timestamp: base.Timestamp,
+			Event:     base.Event,
+		})
+	}
+
+	return parsed, nil
+}
+
+func (jw *Watcher) filterSyncBoundary(lines []parsedLine) []parsedLine {
+	filtered := make([]parsedLine, 0, len(lines))
+
+	for _, line := range lines {
+		if line.Timestamp.Before(jw.lastTimestamp) {
+			jw.logger.Trace(fmt.Sprintf("[filterSync] timestamp %v before lastTimestamp %v, skipping", line.Timestamp, jw.lastTimestamp))
 			continue
 		}
-		jw.lastTimestamp = base.Timestamp
+		jw.lastTimestamp = line.Timestamp
+		filtered = append(filtered, line)
+	}
 
-		switch base.Event {
+	return filtered
+}
+
+func (jw *Watcher) dispatch(lines []parsedLine) {
+	for _, line := range lines {
+		switch line.Event {
 		case Loadout:
 			var event LoadoutEvent
-			if err := json.Unmarshal([]byte(line), &event); err == nil {
-				jw.logger.Trace("[processData] Publishing Loadout")
+			if err := json.Unmarshal(line.Raw, &event); err == nil {
+				jw.logger.Trace("[dispatch] Publishing Loadout")
 				jw.Loadout.Publish(&event)
 			}
 		case FSDJump:
 			var event FSDJumpEvent
-			if err := json.Unmarshal([]byte(line), &event); err == nil {
+			if err := json.Unmarshal(line.Raw, &event); err == nil {
 				jw.logger.Trace(fmt.Sprintf("[FSD_TIMING] FSDJump event: system=%s, timestamp=%v, fuelLevel=%.2f, fuelUsed=%.2f",
 					event.StarSystem, event.Timestamp, event.FuelLevel, event.FuelUsed))
-				jw.logger.Trace("[processData] Publishing FSDJump")
+				jw.logger.Trace("[dispatch] Publishing FSDJump")
 				jw.FSDJump.Publish(&event)
 			}
 		case FSDTarget:
 			var event FSDTargetEvent
-			if err := json.Unmarshal([]byte(line), &event); err == nil {
-				jw.logger.Trace(fmt.Sprintf("[processData] Publishing FSDTarget: %s", event.Name))
+			if err := json.Unmarshal(line.Raw, &event); err == nil {
+				jw.logger.Trace(fmt.Sprintf("[dispatch] Publishing FSDTarget: %s", event.Name))
 				jw.FSDTarget.Publish(&event)
 			} else {
-				jw.logger.Trace(fmt.Sprintf("[processData] FSDTarget unmarshal error: %v", err))
+				jw.logger.Trace(fmt.Sprintf("[dispatch] FSDTarget unmarshal error: %v", err))
 			}
 		case Location:
 			var event LocationEvent
-			if err := json.Unmarshal([]byte(line), &event); err == nil {
-				jw.logger.Trace("[processData] Publishing Location")
+			if err := json.Unmarshal(line.Raw, &event); err == nil {
+				jw.logger.Trace("[dispatch] Publishing Location")
 				jw.Location.Publish(&event)
 			}
 		case StartJump:
 			var event StartJumpEvent
-			if err := json.Unmarshal([]byte(line), &event); err == nil {
+			if err := json.Unmarshal(line.Raw, &event); err == nil {
 				starSystem := "<none>"
 				if event.StarSystem != nil {
 					starSystem = *event.StarSystem
 				}
 				jw.logger.Trace(fmt.Sprintf("[FSD_TIMING] StartJump event: type=%s, system=%s, timestamp=%v",
 					event.JumpType, starSystem, event.Timestamp))
-				jw.logger.Trace(fmt.Sprintf("[processData] Publishing StartJump: %s to %s", event.JumpType, starSystem))
+				jw.logger.Trace(fmt.Sprintf("[dispatch] Publishing StartJump: %s to %s", event.JumpType, starSystem))
 				jw.StartJump.Publish(&event)
 			}
 		}
 	}
-
-	return nil
 }

--- a/journal/watcher.go
+++ b/journal/watcher.go
@@ -3,8 +3,10 @@ package journal
 import (
 	"ed-expedition/lib/channels"
 	"ed-expedition/lib/slice"
+	"ed-expedition/models"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path"
@@ -20,19 +22,19 @@ var journalFilePattern = regexp.MustCompile(`Journal\.(\d{4}-\d{2}-\d{2}T\d{6})\
 const FanoutChannelTimeout = 200 * time.Millisecond
 
 type Watcher struct {
-	dir           string
-	watcher       *fsnotify.Watcher
-	currentFile   string
-	seek          int64
-	lastTimestamp time.Time
-	started       bool
-	logger        wailsLogger.Logger
+	dir         string
+	watcher     *fsnotify.Watcher
+	currentFile string
+	seek        int64
+	started     bool
+	logger      wailsLogger.Logger
 
 	Loadout   *channels.FanoutChannel[*LoadoutEvent]
 	FSDJump   *channels.FanoutChannel[*FSDJumpEvent]
 	FSDTarget *channels.FanoutChannel[*FSDTargetEvent]
 	Location  *channels.FanoutChannel[*LocationEvent]
 	StartJump *channels.FanoutChannel[*StartJumpEvent]
+	SyncState *channels.FanoutChannel[models.JournalSync]
 
 	// Status
 	Scooping            *channels.FanoutChannel[bool]
@@ -65,6 +67,7 @@ func NewWatcher(dir string, logger wailsLogger.Logger) (*Watcher, error) {
 		FSDTarget: channels.NewFanoutChannel[*FSDTargetEvent]("FSDTarget", 32, FanoutChannelTimeout, logger),
 		Location:  channels.NewFanoutChannel[*LocationEvent]("Location", 32, FanoutChannelTimeout, logger),
 		StartJump: channels.NewFanoutChannel[*StartJumpEvent]("StartJump", 32, FanoutChannelTimeout, logger),
+		SyncState: channels.NewFanoutChannel[models.JournalSync]("SyncState", 1, FanoutChannelTimeout, logger),
 
 		Scooping:    channels.NewFanoutChannel[bool]("Scooping", 0, 5*time.Millisecond, logger),
 		Fuel:        channels.NewFanoutChannel[*FuelStatus]("Fuel", 0, 5*time.Millisecond, logger),
@@ -139,6 +142,11 @@ func (jw *Watcher) handleJournalUpdate() error {
 		panic(fmt.Sprintf("Failed to parse journal data: %v", err))
 	}
 
+	if len(lines) == 0 {
+		return nil
+	}
+
+	jw.publishSyncState(lines[len(lines)-1])
 	jw.dispatch(lines)
 
 	return nil
@@ -184,19 +192,44 @@ func (jw *Watcher) parseLines(data []byte) ([]parsedLine, error) {
 	return parsed, nil
 }
 
-func (jw *Watcher) filterSyncBoundary(lines []parsedLine) []parsedLine {
+func (jw *Watcher) filterSyncBoundary(lines []parsedLine, syncState *models.JournalSync) []parsedLine {
 	filtered := make([]parsedLine, 0, len(lines))
+	pastBoundary := syncState.EventHash == ""
 
 	for _, line := range lines {
-		if line.Timestamp.Before(jw.lastTimestamp) {
-			jw.logger.Trace(fmt.Sprintf("[filterSync] timestamp %v before lastTimestamp %v, skipping", line.Timestamp, jw.lastTimestamp))
+		if line.Timestamp.Before(syncState.Timestamp) {
+			jw.logger.Trace(fmt.Sprintf("[filterSync] timestamp %v before %v, skipping", line.Timestamp, syncState.Timestamp))
 			continue
 		}
-		jw.lastTimestamp = line.Timestamp
+
+		if !pastBoundary {
+			if line.Timestamp.After(syncState.Timestamp) {
+				pastBoundary = true
+			} else {
+				// At the boundary timestamp: skip everything up to and
+				// including the hash match
+				pastBoundary = hashLine(line.Raw) == syncState.EventHash
+				continue
+			}
+		}
+
 		filtered = append(filtered, line)
 	}
 
 	return filtered
+}
+
+func hashLine(raw []byte) string {
+	h := fnv.New32a()
+	h.Write(raw)
+	return fmt.Sprintf("%x", h.Sum32())
+}
+
+func (jw *Watcher) publishSyncState(last parsedLine) {
+	jw.SyncState.Publish(models.JournalSync{
+		Timestamp: last.Timestamp,
+		EventHash: hashLine(last.Raw),
+	})
 }
 
 func (jw *Watcher) dispatch(lines []parsedLine) {

--- a/journal/watcher_test.go
+++ b/journal/watcher_test.go
@@ -1,6 +1,7 @@
 package journal
 
 import (
+	"ed-expedition/models"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -96,6 +97,29 @@ func collectTargetEvents(ch chan *FSDTargetEvent, expected int, timeout time.Dur
 	}
 }
 
+func collectSyncStates(ch chan models.JournalSync, expected int, timeout time.Duration) []models.JournalSync {
+	states := make([]models.JournalSync, 0, expected)
+	deadline := time.After(timeout)
+
+	for range expected {
+		select {
+		case state := <-ch:
+			states = append(states, state)
+		case <-deadline:
+			return states
+		}
+	}
+
+	for {
+		select {
+		case state := <-ch:
+			states = append(states, state)
+		case <-time.After(10 * time.Millisecond):
+			return states
+		}
+	}
+}
+
 func collectJumpEvents(ch chan *FSDJumpEvent, expected int, timeout time.Duration) []*FSDJumpEvent {
 	events := make([]*FSDJumpEvent, 0, expected)
 	deadline := time.After(timeout)
@@ -165,8 +189,9 @@ func (s *SyncTestSuite) TestDeletedEarlyParts() {
 	s.createWatcher()
 	ch := s.watcher.FSDTarget.Subscribe()
 
-	since := time.Date(2024, 12, 19, 9, 0, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 19, 9, 0, 0, 0, time.UTC),
+	}))
 
 	events := collectTargetEvents(ch, 2, time.Second)
 	s.Require().Len(events, 2)
@@ -185,8 +210,9 @@ func (s *SyncTestSuite) TestMiddleOfMultipleParts() {
 	logger := s.createWatcherWithRecorder()
 	ch := s.watcher.FSDTarget.Subscribe()
 
-	since := time.Date(2024, 12, 19, 10, 20, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 19, 10, 20, 0, 0, time.UTC),
+	}))
 
 	events := collectTargetEvents(ch, 1, time.Second)
 	s.Require().Len(events, 1)
@@ -194,7 +220,7 @@ func (s *SyncTestSuite) TestMiddleOfMultipleParts() {
 
 	eventsSkipped := 0
 	for _, msg := range logger.Messages {
-		if strings.Contains(msg, "before lastTimestamp") && strings.Contains(msg, "skipping") {
+		if strings.Contains(msg, "[filterSync]") && strings.Contains(msg, "before") && strings.Contains(msg, "skipping") {
 			eventsSkipped++
 		}
 	}
@@ -211,8 +237,9 @@ func (s *SyncTestSuite) TestAllJournalsBeforeSince() {
 	s.createWatcher()
 	ch := s.watcher.FSDTarget.Subscribe()
 
-	since := time.Date(2024, 12, 19, 13, 0, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 19, 13, 0, 0, 0, time.UTC),
+	}))
 
 	events := collectTargetEvents(ch, 1, time.Second)
 	s.Require().Len(events, 1)
@@ -228,8 +255,9 @@ func (s *SyncTestSuite) TestAllJournalsAfterSince() {
 	s.createWatcher()
 	ch := s.watcher.FSDTarget.Subscribe()
 
-	since := time.Date(2024, 12, 18, 0, 0, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 18, 0, 0, 0, 0, time.UTC),
+	}))
 
 	events := collectTargetEvents(ch, 2, time.Second)
 	s.Require().Len(events, 2)
@@ -241,31 +269,48 @@ func (s *SyncTestSuite) TestEmptyDirectory() {
 	s.createWatcher()
 	ch := s.watcher.FSDTarget.Subscribe()
 
-	since := time.Date(2024, 12, 19, 10, 0, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 19, 10, 0, 0, 0, time.UTC),
+	}))
 
 	events := collectTargetEvents(ch, 0, time.Second)
 	s.Len(events, 0)
 }
 
-func (s *SyncTestSuite) TestExactTimestampIncluded() {
-	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
-		fsdTargetEvent("2024-12-19T10:00:00Z", "Before", 1)+"\n"+
-			fsdTargetEvent("2024-12-19T10:05:00Z", "ExactMatch", 2)+"\n"+
-			fsdTargetEvent("2024-12-19T10:10:00Z", "After", 3))
+func (s *SyncTestSuite) TestExactTimestampDedup() {
+	exactEvent := fsdTargetEvent("2024-12-19T10:05:00Z", "ExactMatch", 3)
+	laterEvent := fsdTargetEvent("2024-12-19T10:10:00Z", "later", 6)
+
+	lines := []string{
+		fsdTargetEvent("2024-12-19T10:05:00Z", "pre 1", 1),
+		fsdTargetEvent("2024-12-19T10:05:00Z", "pre 2", 2),
+		exactEvent,
+		fsdTargetEvent("2024-12-19T10:05:00Z", "post 1", 4),
+		fsdTargetEvent("2024-12-19T10:05:00Z", "post 2", 5),
+		laterEvent,
+	}
+
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log", strings.Join(lines, "\n"))
 
 	s.createWatcher()
-	ch := s.watcher.FSDTarget.Subscribe()
+	targetCh := s.watcher.FSDTarget.Subscribe()
+	syncCh := s.watcher.SyncState.Subscribe()
 
-	since := time.Date(2024, 12, 19, 10, 5, 0, 0, time.UTC)
-	s.Require().NoError(s.watcher.Sync(since))
+	s.Require().NoError(s.watcher.Sync(models.JournalSync{
+		Timestamp: time.Date(2024, 12, 19, 10, 5, 0, 0, time.UTC),
+		EventHash: hashLine([]byte(exactEvent)),
+	}))
 
-	// TODO: Exact timestamp dedup requires hash-based approach (see #39).
-	// Events at exactly `since` are currently included (potential duplicate).
-	events := collectTargetEvents(ch, 2, time.Second)
-	s.Require().Len(events, 2)
-	s.Equal("ExactMatch", events[0].Name)
-	s.Equal("After", events[1].Name)
+	events := collectTargetEvents(targetCh, 3, time.Second)
+	s.Require().Len(events, 3)
+	s.Equal("post 1", events[0].Name)
+	s.Equal("post 2", events[1].Name)
+	s.Equal("later", events[2].Name)
+
+	syncUpdates := collectSyncStates(syncCh, 1, time.Second)
+	s.Require().Len(syncUpdates, 1)
+	s.Equal(hashLine([]byte(laterEvent)), syncUpdates[0].EventHash)
+	s.Equal(time.Date(2024, 12, 19, 10, 10, 0, 0, time.UTC), syncUpdates[0].Timestamp)
 }
 
 func TestSyncTestSuite(t *testing.T) {

--- a/journal/watcher_test.go
+++ b/journal/watcher_test.go
@@ -1,11 +1,14 @@
 package journal
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/suite"
 )
 
 // TestLogger implements wails Logger interface for testing
@@ -32,249 +35,21 @@ func (l *RecordingLogger) Warning(message string) {}
 func (l *RecordingLogger) Error(message string)   {}
 func (l *RecordingLogger) Fatal(message string)   {}
 
-func TestWatcher_Sync_DeletedEarlyParts(t *testing.T) {
-	// Test case: First journal is part 3 (parts 1-2 were deleted)
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Create journals starting from part 3 (simulating deleted parts 1-2)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.03.log",
-		`{"timestamp":"2024-12-19T10:05:00Z","event":"FSDTarget","Name":"Sol","SystemAddress":10477373803,"StarClass":"G"}`)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.04.log",
-		`{"timestamp":"2024-12-19T10:10:00Z","event":"FSDTarget","Name":"Alpha Centauri","SystemAddress":123456,"StarClass":"K"}`)
-
-	watcher, err := NewWatcher(tmpDir, &TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	// Subscribe to FSDTarget events
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	// Sync from before all journals
-	since := time.Date(2024, 12, 19, 9, 0, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	// Should receive both events
-	events := collectEvents(targetChan, 2, time.Millisecond*1000)
-	if len(events) != 2 {
-		t.Fatalf("Expected 2 events, got %d", len(events))
-	}
-	if events[0].Name != "Sol" {
-		t.Errorf("Expected first event to be Sol, got %s", events[0].Name)
-	}
-	if events[1].Name != "Alpha Centauri" {
-		t.Errorf("Expected second event to be Alpha Centauri, got %s", events[1].Name)
-	}
+func fsdTargetEvent(timestamp, name string, systemAddress int) string {
+	return fmt.Sprintf(
+		`{"timestamp":"%s","event":"FSDTarget","Name":"%s","SystemAddress":%d,"StarClass":"G"}`,
+		timestamp, name, systemAddress,
+	)
 }
 
-func TestWatcher_Sync_MiddleOfMultipleParts(t *testing.T) {
-	// Test case: Sync in the middle of journal parts
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Create multiple parts for same timestamp
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.01.log",
-		`{"timestamp":"2024-12-19T10:05:00Z","event":"FSDTarget","Name":"Early","SystemAddress":1,"StarClass":"G"}`)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.02.log",
-		`{"timestamp":"2024-12-19T10:15:00Z","event":"FSDTarget","Name":"Middle","SystemAddress":2,"StarClass":"K"}`)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T110000.01.log",
-		`{"timestamp":"2024-12-19T11:05:00Z","event":"FSDTarget","Name":"Late","SystemAddress":3,"StarClass":"M"}`)
-
-	logger := &RecordingLogger{}
-	watcher, err := NewWatcher(tmpDir, logger)
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	// Sync from 10:20 (should start from beginning to catch events after 10:20 in earlier journals)
-	since := time.Date(2024, 12, 19, 10, 20, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	// Should receive only events after 10:20
-	events := collectEvents(targetChan, 1, time.Millisecond*1000)
-	if len(events) != 1 {
-		t.Fatalf("Expected 1 event, got %d", len(events))
-	}
-	if events[0].Name != "Late" {
-		t.Errorf("Expected Late event, got %s", events[0].Name)
-	}
-
-	// Verify all 3 journals were read but 2 events were skipped due to timestamp
-	eventsSkipped := 0
-	for _, msg := range logger.Messages {
-		if strings.Contains(msg, "not after lastTimestamp") && strings.Contains(msg, "skipping") {
-			eventsSkipped++
-		}
-	}
-	if eventsSkipped != 2 {
-		t.Errorf("Expected 2 events to be skipped due to timestamp, got %d", eventsSkipped)
-	}
+func fsdJumpEvent(timestamp, system string, systemAddress int, fuelUsed, fuelLevel, jumpDist float64) string {
+	return fmt.Sprintf(
+		`{"timestamp":"%s","event":"FSDJump","StarSystem":"%s","SystemAddress":%d,"StarPos":[0,0,0],"FuelUsed":%.1f,"FuelLevel":%.1f,"JumpDist":%.1f}`,
+		timestamp, system, systemAddress, fuelUsed, fuelLevel, jumpDist,
+	)
 }
 
-func TestWatcher_Sync_AllJournalsBeforeSince(t *testing.T) {
-	// Test case: All journals are before the 'since' timestamp
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Create journals with events before 'since'
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.01.log",
-		`{"timestamp":"2024-12-19T10:05:00Z","event":"FSDTarget","Name":"Old1","SystemAddress":1,"StarClass":"G"}`)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T110000.01.log",
-		`{"timestamp":"2024-12-19T11:05:00Z","event":"FSDTarget","Name":"Old2","SystemAddress":2,"StarClass":"K"}
-{"timestamp":"2024-12-19T13:30:00Z","event":"FSDTarget","Name":"Recent","SystemAddress":3,"StarClass":"M"}`)
-
-	watcher, err := NewWatcher(tmpDir, &TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	// Sync from 13:00 (last journal started at 11:00, but has event at 13:30)
-	since := time.Date(2024, 12, 19, 13, 0, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	// Should receive only the recent event
-	events := collectEvents(targetChan, 1, time.Millisecond*1000)
-	if len(events) != 1 {
-		t.Fatalf("Expected 1 event, got %d", len(events))
-	}
-	if events[0].Name != "Recent" {
-		t.Errorf("Expected Recent event, got %s", events[0].Name)
-	}
-}
-
-func TestWatcher_Sync_AllJournalsAfterSince(t *testing.T) {
-	// Test case: All journals are after the 'since' timestamp
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.01.log",
-		`{"timestamp":"2024-12-19T10:05:00Z","event":"FSDTarget","Name":"First","SystemAddress":1,"StarClass":"G"}`)
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T110000.01.log",
-		`{"timestamp":"2024-12-19T11:05:00Z","event":"FSDTarget","Name":"Second","SystemAddress":2,"StarClass":"K"}`)
-
-	watcher, err := NewWatcher(tmpDir, &TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	// Sync from way before all journals
-	since := time.Date(2024, 12, 18, 0, 0, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	// Should receive both events
-	events := collectEvents(targetChan, 2, time.Millisecond*1000)
-	t.Logf("Received %d events", len(events))
-	for i, event := range events {
-		t.Logf("Event %d: %s at %v", i, event.Name, event.Timestamp)
-	}
-	if len(events) != 2 {
-		t.Fatalf("Expected 2 events, got %d", len(events))
-	}
-	if events[0].Name != "First" {
-		t.Errorf("Expected first event to be First, got %s", events[0].Name)
-	}
-	if events[1].Name != "Second" {
-		t.Errorf("Expected second event to be Second, got %s", events[1].Name)
-	}
-}
-
-func TestWatcher_Sync_EmptyDirectory(t *testing.T) {
-	// Test case: No journal files
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	watcher, err := NewWatcher(tmpDir, &TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	since := time.Date(2024, 12, 19, 10, 0, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync should not fail on empty directory: %v", err)
-	}
-
-	// Should receive no events
-	events := collectEvents(targetChan, 0, time.Millisecond*1000)
-	if len(events) != 0 {
-		t.Fatalf("Expected 0 events, got %d", len(events))
-	}
-}
-
-// TODO: Exact timestamp dedup requires hash-based approach (see issue)
-// For now, events at exactly `since` are included (potential duplicate).
-// This test verifies current behavior: before is skipped, exact match
-// and after both pass through.
-func TestWatcher_Sync_ExactTimestampIncluded(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "journal-test-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	createJournalWithEvent(t, tmpDir, "Journal.2024-12-19T100000.01.log",
-		`{"timestamp":"2024-12-19T10:00:00Z","event":"FSDTarget","Name":"Before","SystemAddress":1,"StarClass":"G"}
-{"timestamp":"2024-12-19T10:05:00Z","event":"FSDTarget","Name":"ExactMatch","SystemAddress":2,"StarClass":"K"}
-{"timestamp":"2024-12-19T10:10:00Z","event":"FSDTarget","Name":"After","SystemAddress":3,"StarClass":"M"}`)
-
-	watcher, err := NewWatcher(tmpDir, &TestLogger{})
-	if err != nil {
-		t.Fatalf("Failed to create watcher: %v", err)
-	}
-
-	targetChan := watcher.FSDTarget.Subscribe()
-
-	since := time.Date(2024, 12, 19, 10, 5, 0, 0, time.UTC)
-	if err := watcher.Sync(since); err != nil {
-		t.Fatalf("Sync failed: %v", err)
-	}
-
-	events := collectEvents(targetChan, 2, time.Millisecond*1000)
-	if len(events) != 2 {
-		t.Fatalf("Expected 2 events, got %d", len(events))
-	}
-	if events[0].Name != "ExactMatch" {
-		t.Errorf("Expected 'ExactMatch' event, got '%s'", events[0].Name)
-	}
-	if events[1].Name != "After" {
-		t.Errorf("Expected 'After' event, got '%s'", events[1].Name)
-	}
-}
-
-// Helper functions
-
-func createJournalWithEvent(t *testing.T, dir, filename, content string) {
+func writeJournal(t *testing.T, dir, filename, content string) {
 	t.Helper()
 	filePath := filepath.Join(dir, filename)
 	if err := os.WriteFile(filePath, []byte(content+"\n"), 0644); err != nil {
@@ -282,7 +57,23 @@ func createJournalWithEvent(t *testing.T, dir, filename, content string) {
 	}
 }
 
-func collectEvents(ch chan *FSDTargetEvent, expected int, timeout time.Duration) []*FSDTargetEvent {
+func appendJournal(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	filePath := filepath.Join(dir, filename)
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open journal file %s: %v", filename, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content + "\n"); err != nil {
+		t.Fatalf("Failed to append to journal file %s: %v", filename, err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("Failed to sync journal file %s: %v", filename, err)
+	}
+}
+
+func collectTargetEvents(ch chan *FSDTargetEvent, expected int, timeout time.Duration) []*FSDTargetEvent {
 	events := make([]*FSDTargetEvent, 0, expected)
 	deadline := time.After(timeout)
 
@@ -295,13 +86,265 @@ func collectEvents(ch chan *FSDTargetEvent, expected int, timeout time.Duration)
 		}
 	}
 
-	// Drain any extra events
 	for {
 		select {
 		case event := <-ch:
 			events = append(events, event)
-		case <-time.After(time.Millisecond * 10):
+		case <-time.After(10 * time.Millisecond):
 			return events
 		}
 	}
+}
+
+func collectJumpEvents(ch chan *FSDJumpEvent, expected int, timeout time.Duration) []*FSDJumpEvent {
+	events := make([]*FSDJumpEvent, 0, expected)
+	deadline := time.After(timeout)
+
+	for range expected {
+		select {
+		case event := <-ch:
+			events = append(events, event)
+		case <-deadline:
+			return events
+		}
+	}
+
+	for {
+		select {
+		case event := <-ch:
+			events = append(events, event)
+		case <-time.After(10 * time.Millisecond):
+			return events
+		}
+	}
+}
+
+// --- Sync Tests ---
+
+type SyncTestSuite struct {
+	suite.Suite
+	tmpDir  string
+	watcher *Watcher
+}
+
+func (s *SyncTestSuite) SetupTest() {
+	var err error
+	s.tmpDir, err = os.MkdirTemp("", "journal-sync-test-*")
+	s.Require().NoError(err)
+}
+
+func (s *SyncTestSuite) TearDownTest() {
+	if s.watcher != nil {
+		s.watcher.Close()
+	}
+	if s.tmpDir != "" {
+		os.RemoveAll(s.tmpDir)
+	}
+}
+
+func (s *SyncTestSuite) createWatcher() {
+	var err error
+	s.watcher, err = NewWatcher(s.tmpDir, &TestLogger{})
+	s.Require().NoError(err)
+}
+
+func (s *SyncTestSuite) createWatcherWithRecorder() *RecordingLogger {
+	logger := &RecordingLogger{}
+	var err error
+	s.watcher, err = NewWatcher(s.tmpDir, logger)
+	s.Require().NoError(err)
+	return logger
+}
+
+func (s *SyncTestSuite) TestDeletedEarlyParts() {
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.03.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "Sol", 1))
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.04.log",
+		fsdTargetEvent("2024-12-19T10:10:00Z", "Alpha Centauri", 2))
+
+	s.createWatcher()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 19, 9, 0, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	events := collectTargetEvents(ch, 2, time.Second)
+	s.Require().Len(events, 2)
+	s.Equal("Sol", events[0].Name)
+	s.Equal("Alpha Centauri", events[1].Name)
+}
+
+func (s *SyncTestSuite) TestMiddleOfMultipleParts() {
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "Early", 1))
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.02.log",
+		fsdTargetEvent("2024-12-19T10:15:00Z", "Middle", 2))
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T110000.01.log",
+		fsdTargetEvent("2024-12-19T11:05:00Z", "Late", 3))
+
+	logger := s.createWatcherWithRecorder()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 19, 10, 20, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	events := collectTargetEvents(ch, 1, time.Second)
+	s.Require().Len(events, 1)
+	s.Equal("Late", events[0].Name)
+
+	eventsSkipped := 0
+	for _, msg := range logger.Messages {
+		if strings.Contains(msg, "not after lastTimestamp") && strings.Contains(msg, "skipping") {
+			eventsSkipped++
+		}
+	}
+	s.Equal(2, eventsSkipped)
+}
+
+func (s *SyncTestSuite) TestAllJournalsBeforeSince() {
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "Old1", 1))
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T110000.01.log",
+		fsdTargetEvent("2024-12-19T11:05:00Z", "Old2", 2)+"\n"+
+			fsdTargetEvent("2024-12-19T13:30:00Z", "Recent", 3))
+
+	s.createWatcher()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 19, 13, 0, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	events := collectTargetEvents(ch, 1, time.Second)
+	s.Require().Len(events, 1)
+	s.Equal("Recent", events[0].Name)
+}
+
+func (s *SyncTestSuite) TestAllJournalsAfterSince() {
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "First", 1))
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T110000.01.log",
+		fsdTargetEvent("2024-12-19T11:05:00Z", "Second", 2))
+
+	s.createWatcher()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 18, 0, 0, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	events := collectTargetEvents(ch, 2, time.Second)
+	s.Require().Len(events, 2)
+	s.Equal("First", events[0].Name)
+	s.Equal("Second", events[1].Name)
+}
+
+func (s *SyncTestSuite) TestEmptyDirectory() {
+	s.createWatcher()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 19, 10, 0, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	events := collectTargetEvents(ch, 0, time.Second)
+	s.Len(events, 0)
+}
+
+func (s *SyncTestSuite) TestExactTimestampIncluded() {
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:00:00Z", "Before", 1)+"\n"+
+			fsdTargetEvent("2024-12-19T10:05:00Z", "ExactMatch", 2)+"\n"+
+			fsdTargetEvent("2024-12-19T10:10:00Z", "After", 3))
+
+	s.createWatcher()
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	since := time.Date(2024, 12, 19, 10, 5, 0, 0, time.UTC)
+	s.Require().NoError(s.watcher.Sync(since))
+
+	// TODO: Exact timestamp dedup requires hash-based approach (see #39).
+	// Events at exactly `since` are currently included (potential duplicate).
+	events := collectTargetEvents(ch, 2, time.Second)
+	s.Require().Len(events, 2)
+	s.Equal("ExactMatch", events[0].Name)
+	s.Equal("After", events[1].Name)
+}
+
+func TestSyncTestSuite(t *testing.T) {
+	suite.Run(t, new(SyncTestSuite))
+}
+
+// --- Live Watcher Tests ---
+
+type LiveTestSuite struct {
+	suite.Suite
+	tmpDir  string
+	watcher *Watcher
+}
+
+func (s *LiveTestSuite) SetupTest() {
+	var err error
+	s.tmpDir, err = os.MkdirTemp("", "journal-live-test-*")
+	s.Require().NoError(err)
+
+	s.watcher, err = NewWatcher(s.tmpDir, &TestLogger{})
+	s.Require().NoError(err)
+	s.watcher.Start()
+}
+
+func (s *LiveTestSuite) TearDownTest() {
+	if s.watcher != nil {
+		s.watcher.Close()
+	}
+	if s.tmpDir != "" {
+		os.RemoveAll(s.tmpDir)
+	}
+}
+
+func (s *LiveTestSuite) TestNewJournalFile() {
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "Sol", 1))
+
+	events := collectTargetEvents(ch, 1, time.Second)
+	s.Require().Len(events, 1)
+	s.Equal("Sol", events[0].Name)
+}
+
+func (s *LiveTestSuite) TestAppendToExistingJournal() {
+	ch := s.watcher.FSDTarget.Subscribe()
+
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "First", 1))
+
+	events := collectTargetEvents(ch, 1, time.Second)
+	s.Require().Len(events, 1)
+	s.Equal("First", events[0].Name)
+
+	appendJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:10:00Z", "Second", 2))
+
+	events = collectTargetEvents(ch, 1, time.Second)
+	s.Require().Len(events, 1)
+	s.Equal("Second", events[0].Name)
+}
+
+func (s *LiveTestSuite) TestMultipleEventTypes() {
+	targetCh := s.watcher.FSDTarget.Subscribe()
+	jumpCh := s.watcher.FSDJump.Subscribe()
+
+	writeJournal(s.T(), s.tmpDir, "Journal.2024-12-19T100000.01.log",
+		fsdTargetEvent("2024-12-19T10:05:00Z", "Sol", 1)+"\n"+
+			fsdJumpEvent("2024-12-19T10:06:00Z", "Sol", 1, 1.5, 14.5, 10.5))
+
+	targets := collectTargetEvents(targetCh, 1, time.Second)
+	s.Require().Len(targets, 1)
+	s.Equal("Sol", targets[0].Name)
+
+	jumps := collectJumpEvents(jumpCh, 1, time.Second)
+	s.Require().Len(jumps, 1)
+	s.Equal("Sol", jumps[0].StarSystem)
+}
+
+func TestLiveTestSuite(t *testing.T) {
+	suite.Run(t, new(LiveTestSuite))
 }

--- a/journal/watcher_test.go
+++ b/journal/watcher_test.go
@@ -194,7 +194,7 @@ func (s *SyncTestSuite) TestMiddleOfMultipleParts() {
 
 	eventsSkipped := 0
 	for _, msg := range logger.Messages {
-		if strings.Contains(msg, "not after lastTimestamp") && strings.Contains(msg, "skipping") {
+		if strings.Contains(msg, "before lastTimestamp") && strings.Contains(msg, "skipping") {
 			eventsSkipped++
 		}
 	}

--- a/migrations/app_state.go
+++ b/migrations/app_state.go
@@ -1,0 +1,24 @@
+package migrations
+
+var AppStateMigrations = Registry{
+	migrateAppStateV0ToV1,
+}
+
+func migrateAppStateV0ToV1(data map[string]any) error {
+	gd, _ := data["galaxy_decision"].(string)
+	if gd != "not_asked" && gd != "declined" && gd != "accepted" {
+		data["galaxy_decision"] = "not_asked"
+	}
+
+	if loc, ok := data["last_known_location"].(map[string]any); ok {
+		if ts, ok := loc["timestamp"].(string); ok {
+			data["journal_sync"] = map[string]any{
+				"timestamp":  ts,
+				"event_hash": "",
+			}
+		}
+	}
+
+	data["version"] = 1
+	return nil
+}

--- a/models/app_state.go
+++ b/models/app_state.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"ed-expedition/database"
+	"ed-expedition/migrations"
 	"os"
 	"time"
 )
@@ -22,6 +23,13 @@ type AppState struct {
 	GalaxyDownloadedAt *time.Time     `json:"galaxy_downloaded_at,omitempty"`
 
 	JournalDir *string `json:"journal_dir,omitempty"`
+
+	JournalSync *JournalSync `json:"journal_sync,omitempty"`
+}
+
+type JournalSync struct {
+	Timestamp time.Time `json:"timestamp"`
+	EventHash string    `json:"event_hash"`
 }
 
 type Loadout struct {
@@ -58,13 +66,12 @@ func LoadAppState() (*AppState, error) {
 		return &AppState{}, nil
 	}
 
-	state, err := database.ReadJSON[AppState](database.AppStatePath)
+	state, err := database.ReadAndMigrateJSON[AppState](
+		database.AppStatePath,
+		migrations.AppStateMigrations,
+	)
 	if err != nil {
 		return nil, err
-	}
-
-	if state.GalaxyDecision == "" {
-		state.GalaxyDecision = GalaxyNotAsked
 	}
 
 	return state, nil

--- a/services/app_state.go
+++ b/services/app_state.go
@@ -14,10 +14,11 @@ import (
 type AppStateService struct {
 	State        *models.AppState
 	watcher      *journal.Watcher
-	loadoutChan  chan *journal.LoadoutEvent
-	fsdJumpChan  chan *journal.FSDJumpEvent
-	locationChan chan *journal.LocationEvent
-	logger       wailsLogger.Logger
+	loadoutChan   chan *journal.LoadoutEvent
+	fsdJumpChan   chan *journal.FSDJumpEvent
+	locationChan  chan *journal.LocationEvent
+	syncStateChan chan models.JournalSync
+	logger        wailsLogger.Logger
 }
 
 func NewAppStateService(logger wailsLogger.Logger) *AppStateService {
@@ -111,6 +112,14 @@ func (s *AppStateService) Start() {
 			))
 		}
 	}()
+
+	s.syncStateChan = s.watcher.SyncState.Subscribe()
+
+	go func() {
+		for syncState := range s.syncStateChan {
+			s.State.JournalSync = &syncState
+		}
+	}()
 }
 
 func (s *AppStateService) SaveJournalDir(path string) error {
@@ -145,6 +154,10 @@ func (s *AppStateService) Stop() error {
 	if s.locationChan != nil {
 		s.watcher.Location.Unsubscribe(s.locationChan)
 		s.locationChan = nil
+	}
+	if s.syncStateChan != nil {
+		s.watcher.SyncState.Unsubscribe(s.syncStateChan)
+		s.syncStateChan = nil
 	}
 	return nil
 }


### PR DESCRIPTION
Journal timestamps have 1-second resolution. Multiple events can share a timestamp, causing duplicates when syncing from a stored boundary.

**Fix:** Track a FNV-32a hash of the last processed journal line alongside the timestamp in `AppState.JournalSync`. During sync, events at the boundary timestamp are skipped up to and including the hash match.

**Changes:**

- Refactored `processData` into a 3-stage pipeline: `parseLines` → `filterSyncBoundary` → `dispatch`
- `filterSyncBoundary` only runs during sync (live path skips it — `seek` already guarantees only new bytes)
- Watcher publishes sync state via `SyncState` fanout channel; `AppStateService` subscribes and owns the state
- Sync info piggybacks on existing FSDJump/Location saves (see #45 for consolidating save triggers)
- v0→v1 `AppState` migration seeds `JournalSync` from `LastKnownLocation.Timestamp`
- Migrated watcher tests to testify suites, added live watcher tests

Closes #39